### PR TITLE
Feature/add space rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,5 +19,7 @@ module.exports = {
         ignoreAtRules: ['return', 'warn', 'import', 'else'],
       },
     ],
+    'block-opening-brace-space-before': 'always',
+    'declaration-colon-space-after': 'always',
   },
 };


### PR DESCRIPTION
Add style lint rules to force :
- one space before one ```{```
- one space after one ```:```