### PR TITLE
Hotfix/1.1.2 Add order/order rule exception

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/node_modules

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studiometa/stylelint-config",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "StyleLint Configuration",
   "main": "index.js",
   "scripts": {

--- a/rules/property-order.js
+++ b/rules/property-order.js
@@ -13,6 +13,7 @@ module.exports = {
       {
         type: 'at-rule',
         name: 'include',
+        parameter: '^((?!for-each-breakpoints).)*$',
         hasBlock: true,
       },
       'rules',


### PR DESCRIPTION
Hello,
This PR add an exception for `@include for-each-breakpoints` in `order/order` rule to prevent errors throw for this kind of cases : 

```
  .flex {
    display: flex;
  }

  .flex-inline {
    display: inline-flex;
  }

  @include font-size('display-1);
  @include for-each-breakpoints using ($breakpoint) {
    .flex--#{$breakpoint} {
      display: flex;
    }

    .flex-inline--#{$breakpoint} {
      display: inline-flex;
    }
  }
```

The rule will match the first `@include` but not the second one.

Is it ok for you ?