### PR TITLE
Allow Tailwind CSS directives

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,18 @@ module.exports = {
         ignoreAtRules: ['return', 'warn', 'import', 'else'],
       },
     ],
+    'scss/at-rule-no-unknown': [
+      true,
+      {
+        ignoreAtRules: [
+          'tailwind',
+          'apply',
+          'variants',
+          'responsive',
+          'screen',
+        ],
+      },
+    ],
     'block-opening-brace-space-before': 'always',
     'declaration-colon-space-after': 'always',
   },


### PR DESCRIPTION
This PR updates the configuration to allow usage of the directives from Tailwind CSS:

- `@tailwind`
- `@apply`
- `@variants`
- `@responsive`
- `@screen`